### PR TITLE
fix: support dark mode for codemirror tooltips

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -36,6 +36,11 @@
         outline: none !important;
     }
 
+    .cm-tooltip {
+        background-color: var(--color-background) !important;
+        border-color: var(--color-border) !important;
+    }
+
     .gw {
         position: fixed;
         will-change: contents, height, width;


### PR DESCRIPTION
Fixes #3

---

<img width="379" height="85" alt="Screenshot 2025-11-03 at 7 31 10 PM" src="https://github.com/user-attachments/assets/66710eb7-f012-467a-84ae-db01027b9829" />

<img width="390" height="89" alt="Screenshot 2025-11-03 at 7 31 05 PM" src="https://github.com/user-attachments/assets/4296fb9c-d609-4b7f-a812-3349b6105257" />
