### PR TITLE
chore(ui): drop `crypto.randomUUID` in favor of normal `uuid`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "pretty-ms": "^9.3.0",
                 "reka-ui": "^2.7.0",
                 "tw-animate-css": "^1.3.8",
+                "uuid": "^13.0.0",
                 "vee-validate": "^4.15.0",
                 "vue-codemirror": "^6.1.1",
                 "vue-sonner": "^2.0.8",
@@ -2162,6 +2163,20 @@
             },
             "peerDependencies": {
                 "storybook": "^8.6.14"
+            }
+        },
+        "node_modules/@storybook/addon-actions/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@storybook/addon-backgrounds": {
@@ -11754,17 +11769,16 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "dev": true,
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/valid-url": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
         "pretty-ms": "^9.3.0",
         "reka-ui": "^2.7.0",
         "tw-animate-css": "^1.3.8",
+        "uuid": "^13.0.0",
         "vee-validate": "^4.15.0",
         "vue-codemirror": "^6.1.1",
         "vue-sonner": "^2.0.8",

--- a/resources/js/stores/core/useEnvironmentVariablesStore.ts
+++ b/resources/js/stores/core/useEnvironmentVariablesStore.ts
@@ -5,9 +5,9 @@ import {
 } from '@/interfaces/common/env-vars';
 import { type ParameterContract, ParameterType } from '@/interfaces/ui';
 import { defineStore } from 'pinia';
+import { v4 as uuidv4 } from 'uuid';
 import type { ComputedRef, Ref } from 'vue';
-import { computed, onMounted, ref, useId } from 'vue';
-import {v4 as uuidv4} from "uuid";
+import { computed, onMounted, ref } from 'vue';
 
 /*
  * Types & Interfaces.

--- a/resources/js/stores/core/useEnvironmentVariablesStore.ts
+++ b/resources/js/stores/core/useEnvironmentVariablesStore.ts
@@ -6,7 +6,8 @@ import {
 import { type ParameterContract, ParameterType } from '@/interfaces/ui';
 import { defineStore } from 'pinia';
 import type { ComputedRef, Ref } from 'vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, useId } from 'vue';
+import {v4 as uuidv4} from "uuid";
 
 /*
  * Types & Interfaces.
@@ -260,7 +261,7 @@ export const useEnvironmentVariablesStore = defineStore(
 
 function createDefaultCollection(index: number): EnvironmentCollection {
     return {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         name: `Collection ${index}`,
         variables: [],
     };

--- a/resources/js/stores/request/useTabsStore.ts
+++ b/resources/js/stores/request/useTabsStore.ts
@@ -21,7 +21,8 @@ import {
 import { buildRequestUrl, getDefaultPayloadTypeForRoute } from '@/utils/request';
 import { generateValueFromType } from '@/utils/value-generator/generateValueFromType';
 import { defineStore } from 'pinia';
-import { computed, ref } from 'vue';
+import {computed, getCurrentInstance, ref, useId} from 'vue';
+import {v4 as uuidv4} from "uuid";
 
 /**
  * Store for managing application tabs and their associated request states.
@@ -228,7 +229,7 @@ export const useTabsStore = defineStore(
                 return;
             }
 
-            const id = crypto.randomUUID();
+            const id = uuidv4();
             const newTab: Tab = {
                 id,
                 title: route.shortEndpoint || route.endpoint,
@@ -514,7 +515,7 @@ export const useTabsStore = defineStore(
         const restoreFromSharedPayload = (payload: ShareableLinkPayload) => {
             const newRequest = createRequestFromShearableLinkPayload(payload);
 
-            const id = crypto.randomUUID();
+            const id = uuidv4();
             const newTab: Tab = {
                 id,
                 title: payload.endpoint,

--- a/resources/js/stores/request/useTabsStore.ts
+++ b/resources/js/stores/request/useTabsStore.ts
@@ -21,8 +21,8 @@ import {
 import { buildRequestUrl, getDefaultPayloadTypeForRoute } from '@/utils/request';
 import { generateValueFromType } from '@/utils/value-generator/generateValueFromType';
 import { defineStore } from 'pinia';
-import {computed, getCurrentInstance, ref, useId} from 'vue';
-import {v4 as uuidv4} from "uuid";
+import { v4 as uuidv4 } from 'uuid';
+import { computed, ref } from 'vue';
 
 /**
  * Store for managing application tabs and their associated request states.


### PR DESCRIPTION
crypto.randomUUID might not always be available and requires a safe context. We don't need a crypto safe UUID, we just need a simple unique ID.