### PR TITLE
feat(routes): support root level endpoints

### DIFF
--- a/resources/js/utils/routes/route-processor.ts
+++ b/resources/js/utils/routes/route-processor.ts
@@ -66,10 +66,8 @@ export async function processRoutesData(sourceRoutes: SourceRouteConfigArray): P
             });
         });
 
-        // Sort routes by `resource`.
-        processedRoutes[version] = routesInVersion.sort((a, b) =>
-            a.resource.localeCompare(b.resource),
-        );
+        // Routes within a version will pertain the original order from the controller (resource-based).
+        processedRoutes[version] = routesInVersion;
     });
 
     return processedRoutes;

--- a/src/Modules/Routes/Collections/ExtractedRoutesCollection.php
+++ b/src/Modules/Routes/Collections/ExtractedRoutesCollection.php
@@ -5,6 +5,7 @@ namespace Sunchayn\Nimbus\Modules\Routes\Collections;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Sunchayn\Nimbus\Modules\Routes\DataTransferObjects\ExtractedRoute;
+use Sunchayn\Nimbus\Modules\Routes\ValueObjects\Endpoint;
 
 /**
  * @phpstan-type RouteDefinitionShape array{
@@ -32,7 +33,21 @@ class ExtractedRoutesCollection extends Collection
                 static function (self $group): Collection {
                     /** @var Collection<string, self> $groupedByResource */
                     $groupedByResource = $group
-                        ->groupBy(static fn (ExtractedRoute $extractedRoute): string => $extractedRoute->uri->resource);
+                        ->groupBy(static fn (ExtractedRoute $extractedRoute): string => $extractedRoute->uri->resource)
+                        ->sortKeysUsing(function (string $keyA, string $keyB): int {
+                            // If keyA is the root, it should come first (move it "up")
+                            if ($keyA === Endpoint::ROOT_RESOURCE) {
+                                return -1;
+                            }
+
+                            // If keyB is the root, it should come first (move keyA "down")
+                            if ($keyB === Endpoint::ROOT_RESOURCE) {
+                                return 1;
+                            }
+
+                            // Otherwise, sort alphabetically
+                            return strcmp($keyA, $keyB);
+                        });
 
                     return $groupedByResource
                         ->map(

--- a/src/Modules/Routes/ValueObjects/Endpoint.php
+++ b/src/Modules/Routes/ValueObjects/Endpoint.php
@@ -2,18 +2,27 @@
 
 namespace Sunchayn\Nimbus\Modules\Routes\ValueObjects;
 
+use Illuminate\Support\Str;
 use RuntimeException;
 use Sunchayn\Nimbus\Modules\Routes\Services\Uri\NonVersionedUri;
 use Sunchayn\Nimbus\Modules\Routes\Services\Uri\VersionedUri;
 
 readonly class Endpoint
 {
+    public const ROOT_RESOURCE = '<root>';
+
+    public string $resource;
+
     public function __construct(
         public string $version,
-        public string $resource,
+        string $resource,
         public string $value,
         public ?string $shortUriOverride = null,
-    ) {}
+    ) {
+        $this->resource = blank($resource)
+            ? self::ROOT_RESOURCE
+            : $resource;
+    }
 
     public static function fromRaw(string $uri, string $routesPrefix, bool $isVersioned, ?string $shortUriOverride = null): self
     {
@@ -35,11 +44,15 @@ readonly class Endpoint
             return $this->shortUriOverride;
         }
 
-        if ($this->resource === '') {
-            throw new RuntimeException('Invalid ValueObject. The resource cannot be empty.');
+        if ($this->resource === self::ROOT_RESOURCE) {
+            return '/';
         }
 
-        $resourcePos = strpos($this->value, '/'.$this->resource);
+        // We try to find the resource segment by checking if it is the beginning of a string,
+        // or looking for it with a leading slash, which is common for prefixed or versioned routes.
+        $resourcePos = str_starts_with($this->value, $this->resource)
+            ? 0
+            : strpos($this->value, '/'.$this->resource);
 
         if ($resourcePos === false) {
             throw new RuntimeException('Invalid ValueObject. The `resource` MUST exist in the URI.');
@@ -48,7 +61,8 @@ readonly class Endpoint
         // To get the short URL, we remove everything before the resource.
         // This will include things like the versioning and the API prefix when provided.
         // @example /rest-api/v1/users/{user} -> /users/{user}
-        // @example users/{user} -> users/{user}
-        return substr($this->value, $resourcePos);
+        // @example users/{user} -> /users/{user}
+        // @example / -> /
+        return Str::start(substr($this->value, $resourcePos), '/');
     }
 }

--- a/tests/App/Modules/Routes/Collections/ExtractedRoutesCollectionUnitTest.php
+++ b/tests/App/Modules/Routes/Collections/ExtractedRoutesCollectionUnitTest.php
@@ -35,7 +35,7 @@ class ExtractedRoutesCollectionUnitTest extends TestCase
 
         $output = $this->replaceTraceWithPlaceholder($output);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $output,
         );
@@ -89,6 +89,27 @@ class ExtractedRoutesCollectionUnitTest extends TestCase
             ],
             'expected' => [
                 'v1' => [
+                    'posts' => [
+                        [
+                            'uri' => '/api/posts',
+                            'shortUri' => 'posts',
+                            'methods' => ['POST'],
+                            'schema' => [
+                                '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                                'type' => 'object',
+                                'properties' => [
+                                    'type' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                                'required' => [],
+                                'additionalProperties' => false,
+                            ],
+                            'extractionError' => null,
+                            'metadata' => [],
+                            'keywords' => ['/api/posts', '/posts'],
+                        ],
+                    ],
                     'users' => [
                         [
                             'uri' => '/api/users',
@@ -119,27 +140,6 @@ class ExtractedRoutesCollectionUnitTest extends TestCase
                             'extractionError' => null,
                             'metadata' => [],
                             'keywords' => ['/api/users', '/users'],
-                        ],
-                    ],
-                    'posts' => [
-                        [
-                            'uri' => '/api/posts',
-                            'shortUri' => 'posts',
-                            'methods' => ['POST'],
-                            'schema' => [
-                                '$schema' => 'https://json-schema.org/draft/2020-12/schema',
-                                'type' => 'object',
-                                'properties' => [
-                                    'type' => [
-                                        'type' => 'string',
-                                    ],
-                                ],
-                                'required' => [],
-                                'additionalProperties' => false,
-                            ],
-                            'extractionError' => null,
-                            'metadata' => [],
-                            'keywords' => ['/api/posts', '/posts'],
                         ],
                     ],
                 ],
@@ -208,6 +208,96 @@ class ExtractedRoutesCollectionUnitTest extends TestCase
 <p class="text-xs">[trace]</p>',
                             'metadata' => [],
                             'keywords' => ['/api/users', '/users'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'Root level endpoints' => [
+            'items' => [
+                new ExtractedRoute(
+                    uri: new Endpoint(
+                        version: 'v1',
+                        resource: '',
+                        value: '/',
+                    ),
+                    methods: ['GET'],
+                    schema: Schema::empty(),
+                    keywords: ['/'],
+                ),
+                new ExtractedRoute(
+                    uri: new Endpoint(
+                        version: 'v1',
+                        resource: '/',
+                        value: '/_shouldnt_be_first',
+                    ),
+                    methods: ['GET'],
+                    schema: Schema::empty(),
+                    keywords: ['::fake::'],
+                ),
+                new ExtractedRoute(
+                    uri: new Endpoint(
+                        version: 'v1',
+                        resource: 'users',
+                        value: '/users',
+                    ),
+                    methods: ['GET'],
+                    schema: Schema::empty(),
+                    keywords: ['/users'],
+                ),
+            ],
+            'expected' => [
+                'v1' => [
+                    '<root>' => [
+                        [
+                            'uri' => '/',
+                            'shortUri' => '',
+                            'methods' => ['GET'],
+                            'schema' => [
+                                '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                                'type' => 'object',
+                                'properties' => [],
+                                'required' => [],
+                                'additionalProperties' => false,
+                            ],
+                            'extractionError' => null,
+                            'metadata' => [],
+                            'keywords' => ['/'],
+                        ],
+                    ],
+                    '/' => [ // <- This is just to test the order is preferring <root> over anything else.
+                        [
+                            'uri' => '/_shouldnt_be_first',
+                            'shortUri' => '_shouldnt_be_first',
+                            'methods' => ['GET'],
+                            'schema' => [
+                                '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                                'type' => 'object',
+                                'properties' => [],
+                                'required' => [],
+                                'additionalProperties' => false,
+                            ],
+                            'extractionError' => null,
+                            'metadata' => [],
+                            'keywords' => ['::fake::'],
+                        ],
+                    ],
+                    'users' => [
+                        [
+                            'uri' => '/users',
+                            'shortUri' => 'users',
+                            'methods' => ['GET'],
+                            'schema' => [
+                                '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+                                'type' => 'object',
+                                'properties' => [],
+                                'required' => [],
+                                'additionalProperties' => false,
+                            ],
+                            'extractionError' => null,
+                            'metadata' => [],
+                            'keywords' => ['/users'],
                         ],
                     ],
                 ],

--- a/tests/App/Modules/Routes/ValueObjects/EndpointUnitTest.php
+++ b/tests/App/Modules/Routes/ValueObjects/EndpointUnitTest.php
@@ -78,11 +78,25 @@ class EndpointUnitTest extends TestCase
             'expectedResource' => 'users',
         ];
 
+        yield 'root level uri' => [
+            'uri' => '/',
+            'routesPrefix' => '/',
+            'expectedVersion' => 'v1',
+            'expectedResource' => '<root>',
+        ];
+
+        yield 'versioned root uri' => [
+            'uri' => '/v1',
+            'routesPrefix' => '',
+            'expectedVersion' => 'v1',
+            'expectedResource' => '<root>',
+        ];
+
         yield 'empty uri' => [
             'uri' => '',
             'routesPrefix' => '',
             'expectedVersion' => 'v1', // <- Default version.
-            'expectedResource' => '',
+            'expectedResource' => '<root>',
         ];
     }
 
@@ -138,11 +152,18 @@ class EndpointUnitTest extends TestCase
             'expectedResource' => 'posts',
         ];
 
+        yield 'root level uri' => [
+            'uri' => '/',
+            'routesPrefix' => '/',
+            'expectedVersion' => 'n/a',
+            'expectedResource' => '<root>',
+        ];
+
         yield 'empty uri' => [
             'uri' => '',
             'routesPrefix' => '',
             'expectedVersion' => 'n/a',
-            'expectedResource' => '',
+            'expectedResource' => '<root>',
         ];
     }
 
@@ -196,6 +217,27 @@ class EndpointUnitTest extends TestCase
             'resource' => 'users',
             'value' => '/users/{user}',
             'expectedShortUri' => '/users/{user}',
+        ];
+
+        yield 'uri without leading slash in value is handled correctly' => [
+            'version' => 'n/a',
+            'resource' => 'users',
+            'value' => 'users/{user}',
+            'expectedShortUri' => '/users/{user}',
+        ];
+
+        yield 'root level endpoint' => [
+            'version' => 'n/a',
+            'resource' => '',
+            'value' => '/',
+            'expectedShortUri' => '/',
+        ];
+
+        yield 'versioned root endpoint' => [
+            'version' => 'v1',
+            'resource' => '',
+            'value' => '/v1',
+            'expectedShortUri' => '/',
         ];
 
         yield 'simple resource without parameters' => [
@@ -255,13 +297,6 @@ class EndpointUnitTest extends TestCase
 
     public static function invalidShortUriProvider(): Generator
     {
-        yield 'empty resource' => [
-            'version' => 'v1',
-            'resource' => '',
-            'value' => '/v1/users',
-            'expectedMessage' => 'Invalid ValueObject. The resource cannot be empty.',
-        ];
-
         yield 'resource not in uri' => [
             'version' => 'v1',
             'resource' => 'posts',
@@ -273,13 +308,6 @@ class EndpointUnitTest extends TestCase
             'version' => 'v1',
             'resource' => 'Users',
             'value' => '/v1/users',
-            'expectedMessage' => 'Invalid ValueObject. The `resource` MUST exist in the URI.',
-        ];
-
-        yield 'resource without leading slash in uri' => [
-            'version' => 'n/a',
-            'resource' => 'users',
-            'value' => 'users/{user}',
             'expectedMessage' => 'Invalid ValueObject. The `resource` MUST exist in the URI.',
         ];
 


### PR DESCRIPTION
resolves #71

---

(note: the root '/' slash endpoint will be grouped within a special <root> resource)

<img width="364" height="415" alt="Screenshot 2026-03-30 at 01 20 54" src="https://github.com/user-attachments/assets/e0ec8586-f5d5-417d-81ff-13eec03b90d4" />

