### PR TITLE
build: run CI jobs efficently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [ base ]
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix-code-issues:
+    uses: ./.github/workflows/code-fix.yml
+    secrets: inherit
+
+  php-tests:
+    needs: fix-code-issues
+    if: always()
+    uses: ./.github/workflows/php-tests.yml
+    secrets: inherit
+
+  js-tests:
+    needs: fix-code-issues
+    if: always()
+    uses: ./.github/workflows/js-tests.yml
+    secrets: inherit
+
+  e2e-tests:
+    needs: fix-code-issues
+    if: always()
+    uses: ./.github/workflows/e2e-tests.yml
+    secrets: inherit
+
+  phpstan:
+    needs: fix-code-issues
+    if: always()
+    uses: ./.github/workflows/phpstan.yml
+    secrets: inherit
+
+  types-check:
+    needs: fix-code-issues
+    if: always()
+    uses: ./.github/workflows/types-check.yml
+    secrets: inherit

--- a/.github/workflows/code-fix.yml
+++ b/.github/workflows/code-fix.yml
@@ -1,9 +1,8 @@
 name: fix-code-issues
 
 on:
-  push:
-    branches: [ base ]
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,9 @@
 name: run-e2e-tests
+
 on:
-  push:
-    branches: [ base ]
-  pull_request:
-    branches: [ base ]
+  workflow_call:
+  workflow_dispatch:
+
 jobs:
   test:
     timeout-minutes: 8

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,9 +1,8 @@
 name: run-js-tests
 
 on:
-  pull_request:
-  push:
-    branches: [ base ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -42,4 +41,3 @@ jobs:
       - name: Run tests
         if: steps.filter.outputs.js == 'true'
         run: npm run test
-

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,9 +1,8 @@
 name: run-php-tests
 
 on:
-  pull_request:
-  push:
-    branches: [ base ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   changes:
@@ -100,4 +99,3 @@ jobs:
           file: ./build/coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,9 +1,8 @@
 name: phpstan
 
 on:
-  push:
-    branches: [ base ]
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   phpstan:

--- a/.github/workflows/types-check.yml
+++ b/.github/workflows/types-check.yml
@@ -1,9 +1,8 @@
 name: run-types-check
 
 on:
-  push:
-    branches: [ base ]
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -42,4 +41,3 @@ jobs:
       - name: Run Type Checks
         if: steps.filter.outputs.types == 'true'
         run: npm run type:check
-

--- a/tests/App/Modules/Relay/Authorization/Handlers/ImpersonateUserAuthorizationHandlerFunctionalTest.php
+++ b/tests/App/Modules/Relay/Authorization/Handlers/ImpersonateUserAuthorizationHandlerFunctionalTest.php
@@ -93,7 +93,7 @@ class ImpersonateUserAuthorizationHandlerFunctionalTest extends TestCase
 
         // Anticipate
 
-        $this->expectException( InvalidAuthorizationValueException::class);
+        $this->expectException(InvalidAuthorizationValueException::class);
 
         $this->expectExceptionMessage('User ID didn\'t resolve to a user to impersonate.');
 

--- a/tests/App/Modules/Relay/Authorization/Handlers/ImpersonateUserAuthorizationHandlerFunctionalTest.php
+++ b/tests/App/Modules/Relay/Authorization/Handlers/ImpersonateUserAuthorizationHandlerFunctionalTest.php
@@ -93,7 +93,7 @@ class ImpersonateUserAuthorizationHandlerFunctionalTest extends TestCase
 
         // Anticipate
 
-        $this->expectException(InvalidAuthorizationValueException::class);
+        $this->expectException( InvalidAuthorizationValueException::class);
 
         $this->expectExceptionMessage('User ID didn\'t resolve to a user to impersonate.');
 


### PR DESCRIPTION
This makes the job that might push commits run first and the rest wait, so jobs are not running in vain for the first commit.

<img width="1395" height="466" alt="Screenshot 2026-04-05 at 20 38 05" src="https://github.com/user-attachments/assets/64e2c874-db76-4bfc-aa84-d917c80a9238" />

