### PR TITLE
feat: configurable brand name defaulting to the application name

### DIFF
--- a/config/nimbus.php
+++ b/config/nimbus.php
@@ -17,6 +17,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | The name shown as the Nimbus brand heading in the UI. When null it falls
+    | back to your application's name (config('app.name')) so the playground is
+    | badged with the host app. Set a string here to override.
+    |
+    */
+
+    'app_name' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Application
     |--------------------------------------------------------------------------
     |

--- a/resources/js/components/domain/RoutesExplorer/RouteExplorerBranding.vue
+++ b/resources/js/components/domain/RoutesExplorer/RouteExplorerBranding.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 /**
  * @component RouteExplorerBranding
- * @description Branding text/logo for the route explorer.
+ * @description Branding text/logo for the route explorer. Shows the configured
+ * application name (defaults to the host app's APP_NAME via nimbus.app_name).
  */
+import { useConfigStore } from '@/stores';
 
 /*
  * Types & Interfaces.
@@ -15,8 +17,12 @@ export interface AppRouteExplorerBrandingProps {}
  */
 
 defineProps<AppRouteExplorerBrandingProps>();
+
+const configStore = useConfigStore();
 </script>
 
 <template>
-    <div class="text-foreground flex-1 text-xl font-medium">Nimbus</div>
+    <div class="text-foreground flex-1 text-xl font-medium">
+        {{ configStore.appName }}
+    </div>
 </template>

--- a/resources/js/stores/core/useConfigStore.ts
+++ b/resources/js/stores/core/useConfigStore.ts
@@ -13,6 +13,7 @@ export type GlobalHeadersArray = Array<{
 
 // TODO [Refactor] convert this to a plain module.
 export const useConfigStore = defineStore('config', () => {
+    const appName = (window.Nimbus?.appName as string) || 'Nimbus';
     const urlBase = (window.Nimbus?.apiBaseUrl as string) || 'http://localhost';
     const isVersioned = (window.Nimbus?.isVersioned as boolean) || false;
     const basePath = (window.Nimbus?.basePath as string) || '';
@@ -36,6 +37,7 @@ export const useConfigStore = defineStore('config', () => {
     const userId = currentUser?.id ?? null;
 
     return {
+        appName,
         apiUrl: urlBase,
         appBasePath: basePath,
         headers: globalHeaders,

--- a/resources/js/tests/components/domain/RoutesExplorer/RouteExplorerBranding.test.ts
+++ b/resources/js/tests/components/domain/RoutesExplorer/RouteExplorerBranding.test.ts
@@ -1,0 +1,44 @@
+import RouteExplorerBranding from '@/components/domain/RoutesExplorer/RouteExplorerBranding.vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+
+const mockConfigStore = reactive({ appName: 'Nimbus' });
+
+vi.mock('@/stores', async importOriginal => {
+    const actual = await importOriginal<object>();
+
+    return {
+        ...actual,
+        useConfigStore: () => mockConfigStore,
+    };
+});
+
+describe('RouteExplorerBranding', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        mockConfigStore.appName = 'Nimbus';
+    });
+
+    it('renders the configured application name', () => {
+        mockConfigStore.appName = 'Fliip App';
+
+        const wrapper = mount(RouteExplorerBranding);
+
+        expect(wrapper.text()).toBe('Fliip App');
+    });
+
+    it('keeps the brand heading classes', () => {
+        const wrapper = mount(RouteExplorerBranding);
+
+        expect(wrapper.get('div').classes()).toEqual(
+            expect.arrayContaining([
+                'text-foreground',
+                'flex-1',
+                'text-xl',
+                'font-medium',
+            ]),
+        );
+    });
+});

--- a/resources/js/tests/stores/useConfigStore.test.ts
+++ b/resources/js/tests/stores/useConfigStore.test.ts
@@ -65,5 +65,23 @@ describe('useConfigStore', () => {
             expect(store.isLoggedIn).toBe(true);
             expect(store.userId).toBe(99);
         });
+
+        it('reads the configured application name', () => {
+            window.Nimbus = {
+                ...window.Nimbus,
+                appName: 'Fliip',
+            };
+
+            expect(useConfigStore().appName).toBe('Fliip');
+        });
+
+        it('falls back to "Nimbus" when no application name is configured', () => {
+            window.Nimbus = {
+                ...window.Nimbus,
+                appName: undefined,
+            };
+
+            expect(useConfigStore().appName).toBe('Nimbus');
+        });
     });
 });

--- a/resources/types/global.d.ts
+++ b/resources/types/global.d.ts
@@ -1,6 +1,7 @@
 import { SharedState } from '../js/interfaces/share';
 
 interface NimbusConfig {
+    appName?: string;
     basePath: string;
     routes: string | null;
     headers: string | null;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -40,6 +40,7 @@
         );
 
         $config = \Illuminate\Support\Js::from([
+            'appName' => config('nimbus.app_name') ?: config('app.name', 'Nimbus'),
             'basePath' => $appBasePath . '/' . ltrim(config('nimbus.prefix'), '/'),
             'routes' => isset($routes) ? json_encode($routes) : null,
             'headers' => isset($headers) ? json_encode($headers) : null,

--- a/tests/Integration/NimbusIndexTest.php
+++ b/tests/Integration/NimbusIndexTest.php
@@ -219,6 +219,40 @@ class NimbusIndexTest extends TestCase
         $response->assertViewHas(['routes', 'headers', 'currentUser']);
     }
 
+    public function test_it_injects_the_configured_app_name(): void
+    {
+        // Arrange
+
+        config(['nimbus.app_name' => 'Acme API']);
+
+        // Act
+
+        $response = $this->get(route('nimbus.index'));
+
+        // Assert
+
+        $response->assertStatus(200);
+
+        // The name is embedded in the window.Nimbus config (Js::from output).
+        $response->assertSee('Acme API', false);
+    }
+
+    public function test_it_falls_back_to_the_application_name_when_app_name_is_null(): void
+    {
+        // Arrange
+
+        config(['nimbus.app_name' => null, 'app.name' => 'Host Application']);
+
+        // Act
+
+        $response = $this->get(route('nimbus.index'));
+
+        // Assert
+
+        $response->assertStatus(200);
+        $response->assertSee('Host Application', false);
+    }
+
     public function test_it_redirects_to_new_application(): void
     {
         // Arrange


### PR DESCRIPTION
## Summary

The route-explorer brand heading was hardcoded to "Nimbus". This makes it configurable and defaults it to the host application's name, so the playground is badged with the app it runs in.

## What is included

- A nimbus.app_name config value. When null it falls back to config('app.name'), so out of the box the heading shows the application name.
- The value is injected via window.Nimbus.appName and exposed through useConfigStore.
- RouteExplorerBranding renders the configured name.

## Notes

- Non-breaking. With no configuration the heading shows the application name, and an explicit nimbus.app_name overrides it.
- Config stays env-free (matches the existing convention and larastan.noEnvCallsOutsideOfConfig): app_name defaults to null and resolves in the view.
- resources/dist is rebuilt and committed.

## Tests

- PHP: NimbusIndexTest covers the injected name and the fallback to the application name.
- JS: RouteExplorerBranding renders the configured name and useConfigStore reads it.
- Full suites, PHPStan, Rector (dry-run), Pint and type:check pass locally.
