### PR TITLE
fix(routes): stop route extraction from executing application code

### DIFF
--- a/src/Modules/Routes/Extractor/Ast/ConvertNodeToConcreteValue.php
+++ b/src/Modules/Routes/Extractor/Ast/ConvertNodeToConcreteValue.php
@@ -109,7 +109,20 @@ class ConvertNodeToConcreteValue
             return null;
         }
 
-        return $staticCall->class->name::{$staticCall->name->name}(...$arguments);
+        $className = $staticCall->class->name;
+        $methodName = $staticCall->name->name;
+
+        // Relative keywords only resolve inside a class scope; invoking them here fatals.
+        if (self::isUnresolvableClassName($className)) {
+            return null;
+        }
+
+        // Skip missing / non-callable targets so extraction never fatals on app code.
+        if (! is_callable([$className, $methodName])) {
+            return null;
+        }
+
+        return $className::{$methodName}(...$arguments);
     }
 
     /**
@@ -139,7 +152,22 @@ class ConvertNodeToConcreteValue
             return null;
         }
 
-        return new $new->class->name(...$arguments);
+        $className = $new->class->name;
+
+        // Relative keywords and missing classes would fatal outside a class scope.
+        if (self::isUnresolvableClassName($className) || ! class_exists($className)) {
+            return null;
+        }
+
+        return new $className(...$arguments);
+    }
+
+    /**
+     * Detects relative class keywords that cannot be resolved during AST evaluation.
+     */
+    private static function isUnresolvableClassName(string $className): bool
+    {
+        return in_array(strtolower($className), ['static', 'self', 'parent'], true);
     }
 
     private static function resolveConstant(Node\Expr\ConstFetch $constFetch): mixed

--- a/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
+++ b/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
@@ -276,13 +276,10 @@ class ValidateCallVisitor extends NodeVisitorAbstract
             return;
         }
 
-        $rules = ConvertNodeToConcreteValue::process($returnStatement->expr, $this->context);
-
-        if (! is_array($rules)) {
-            return;
-        }
-
-        $this->rules = Ruleset::fromLaravelRules($rules);
+        // isArrayReturn() already guarantees an array literal; process() keeps it as array.
+        $this->rules = Ruleset::fromLaravelRules(
+            ConvertNodeToConcreteValue::process($returnStatement->expr, $this->context)
+        );
     }
 
     private function isArrayReturn(Node\Stmt\Return_ $return): bool

--- a/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
+++ b/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
@@ -7,8 +7,11 @@ use Illuminate\Support\Arr;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
@@ -35,6 +38,8 @@ class ValidateCallVisitor extends NodeVisitorAbstract
     /** @var array<string, Node\Stmt\ClassMethod> */
     private array $classMethodNodes = [];
 
+    private ?string $currentClassName = null;
+
     private ?Ruleset $rules = null;
 
     /** @var array<string, mixed> Variables defined within the method */
@@ -47,9 +52,12 @@ class ValidateCallVisitor extends NodeVisitorAbstract
 
     public function beforeTraverse(array $nodes): array
     {
+        // Resolve names first so self/static become the enclosing FQCN.
+        $nodes = $this->qualifyClassTypeHinting($nodes);
+
         $this->gatherClassMethods($nodes);
 
-        return $this->qualifyClassTypeHinting($nodes);
+        return $nodes;
     }
 
     public function getRules(): Ruleset
@@ -173,9 +181,13 @@ class ValidateCallVisitor extends NodeVisitorAbstract
             return;
         }
 
-        $this->rules = Ruleset::fromLaravelRules(
-            ConvertNodeToConcreteValue::process($argNode, $this->context)
-        );
+        $rules = ConvertNodeToConcreteValue::process($argNode, $this->context);
+
+        if (! is_array($rules)) {
+            return;
+        }
+
+        $this->rules = Ruleset::fromLaravelRules($rules);
     }
 
     private function extractValidationRulesArgument(MethodCall $methodCall, ?string $methodName): ?Node
@@ -188,19 +200,53 @@ class ValidateCallVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @phpstan-assert-if-true MethodCall $argNode
+     * @phpstan-assert-if-true MethodCall|StaticCall $argNode
      */
     private function isNestedMethodCall(Node $argNode): bool
     {
-        if (! ($argNode instanceof MethodCall)) {
+        if ($argNode instanceof MethodCall) {
+            if (! ($argNode->name instanceof Identifier)) {
+                return false;
+            }
+
+            return array_key_exists($argNode->name->name, $this->classMethodNodes);
+        }
+
+        // e.g. $request->validate(self::getValidationRules())
+        if ($argNode instanceof StaticCall) {
+            if (! ($argNode->name instanceof Identifier) || ! ($argNode->class instanceof Name)) {
+                return false;
+            }
+
+            if (! array_key_exists($argNode->name->name, $this->classMethodNodes)) {
+                return false;
+            }
+
+            return $this->isCurrentClassReference($argNode->class);
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a static call targets the controller under analysis.
+     *
+     * NameResolver rewrites self/static to the FQCN; accept both so helpers like
+     * self::getValidationRules() can be extracted via AST without invoking them.
+     */
+    private function isCurrentClassReference(Name $class): bool
+    {
+        $resolved = ltrim($class->toString(), '\\');
+
+        if (in_array(strtolower($resolved), ['self', 'static'], true)) {
+            return true;
+        }
+
+        if ($this->currentClassName === null) {
             return false;
         }
 
-        if (! ($argNode->name instanceof Identifier)) {
-            return false;
-        }
-
-        return array_key_exists($argNode->name->name, $this->classMethodNodes);
+        return strcasecmp($resolved, ltrim($this->currentClassName, '\\')) === 0;
     }
 
     private function processNestedMethodCall(string $methodName): void
@@ -230,9 +276,13 @@ class ValidateCallVisitor extends NodeVisitorAbstract
             return;
         }
 
-        $this->rules = Ruleset::fromLaravelRules(
-            ConvertNodeToConcreteValue::process($returnStatement->expr, $this->context)
-        );
+        $rules = ConvertNodeToConcreteValue::process($returnStatement->expr, $this->context);
+
+        if (! is_array($rules)) {
+            return;
+        }
+
+        $this->rules = Ruleset::fromLaravelRules($rules);
     }
 
     private function isArrayReturn(Node\Stmt\Return_ $return): bool
@@ -261,7 +311,13 @@ class ValidateCallVisitor extends NodeVisitorAbstract
 
     private function storeVariableAssignment(Assign $assign): void
     {
-        if ($assign->expr instanceof MethodCall) {
+        // Skip calls/instantiation used only for variable context — evaluating them
+        // would run application code (e.g. User::create) during schema extraction.
+        if (
+            $assign->expr instanceof MethodCall
+            || $assign->expr instanceof StaticCall
+            || $assign->expr instanceof New_
+        ) {
             return;
         }
 
@@ -290,6 +346,13 @@ class ValidateCallVisitor extends NodeVisitorAbstract
 
         if ($classNode === null) {
             return;
+        }
+
+        // Prefer the NameResolver-provided FQCN when present.
+        if (isset($classNode->namespacedName)) {
+            $this->currentClassName = $classNode->namespacedName->toString();
+        } elseif ($classNode->name !== null) {
+            $this->currentClassName = $classNode->name->toString();
         }
 
         foreach ($classNode->stmts as $stmt) {

--- a/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
+++ b/src/Modules/Routes/Extractor/Ast/ValidateCallVisitor.php
@@ -234,9 +234,9 @@ class ValidateCallVisitor extends NodeVisitorAbstract
      * NameResolver rewrites self/static to the FQCN; accept both so helpers like
      * self::getValidationRules() can be extracted via AST without invoking them.
      */
-    private function isCurrentClassReference(Name $class): bool
+    private function isCurrentClassReference(Name $name): bool
     {
-        $resolved = ltrim($class->toString(), '\\');
+        $resolved = ltrim($name->toString(), '\\');
 
         if (in_array(strtolower($resolved), ['self', 'static'], true)) {
             return true;

--- a/tests/App/Modules/Routes/Extractors/Ast/ConvertNodeToConcreteValueUnitTest.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/ConvertNodeToConcreteValueUnitTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast;
+
+use Generator;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sunchayn\Nimbus\Modules\Routes\Extractor\Ast\ConvertNodeToConcreteValue;
+
+#[CoversClass(ConvertNodeToConcreteValue::class)]
+class ConvertNodeToConcreteValueUnitTest extends TestCase
+{
+    #[DataProvider('relativeClassKeywordScenariosDataProvider')]
+    public function test_it_skips_relative_class_keywords_without_throwing(
+        string $phpCode,
+    ): void {
+        // Arrange
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($phpCode);
+
+        // `$x = <expr>;` → expression statement → assign → right-hand side
+        $node = $ast[0]->expr->expr;
+
+        // Act
+
+        $result = ConvertNodeToConcreteValue::process($node);
+
+        // Assert
+
+        $this->assertNull($result);
+    }
+
+    public static function relativeClassKeywordScenariosDataProvider(): Generator
+    {
+        yield 'static call' => [
+            'phpCode' => '<?php $x = static::getEloquentQuery();',
+        ];
+
+        yield 'self call' => [
+            'phpCode' => '<?php $x = self::getEloquentQuery();',
+        ];
+
+        yield 'parent call' => [
+            'phpCode' => '<?php $x = parent::getEloquentQuery();',
+        ];
+
+        yield 'new static' => [
+            'phpCode' => '<?php $x = new static();',
+        ];
+
+        yield 'new self' => [
+            'phpCode' => '<?php $x = new self();',
+        ];
+    }
+
+    public function test_it_still_resolves_concrete_static_calls(): void
+    {
+        // Arrange
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse('<?php $x = \Illuminate\Support\Str::upper("hi");');
+        $node = $ast[0]->expr->expr;
+
+        // Act
+
+        $result = ConvertNodeToConcreteValue::process($node);
+
+        // Assert
+
+        $this->assertSame('HI', $result);
+    }
+
+    public function test_it_skips_non_callable_static_methods_without_throwing(): void
+    {
+        // Arrange — use a concrete class without __callStatic so is_callable is false
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse('<?php $x = \stdClass::thisMethodDoesNotExist();');
+        $node = $ast[0]->expr->expr;
+
+        // Act
+
+        $result = ConvertNodeToConcreteValue::process($node);
+
+        // Assert
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/App/Modules/Routes/Extractors/Ast/Stubs/SideEffectStub.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/Stubs/SideEffectStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast\Stubs;
+
+/**
+ * Tracks whether extraction accidentally executed application code.
+ */
+class SideEffectStub
+{
+    public static bool $called = false;
+
+    public static function boom(): string
+    {
+        self::$called = true;
+
+        return 'boom';
+    }
+
+    public function __construct()
+    {
+        self::$called = true;
+    }
+
+    public static function reset(): void
+    {
+        self::$called = false;
+    }
+}

--- a/tests/App/Modules/Routes/Extractors/Ast/Stubs/controller.stub.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/Stubs/controller.stub.php
@@ -145,6 +145,38 @@ class TestController
         $validated = $request->validate(static::getValidationRules());
     }
 
+    public function call_with_explicit_class_validation_rules(Request $request): void
+    {
+        // NameResolver keeps/rewrites this to the enclosing FQCN (not self/static keywords).
+        $validated = $request->validate(TestController::getValidationRules());
+    }
+
+    public function call_with_unknown_self_validation_rules(Request $request): void
+    {
+        // Method is not defined on the class — nested lookup fails, concrete value is null.
+        $validated = $request->validate(self::missingValidationRulesHelper());
+    }
+
+    public function call_with_variable_class_static_validation_rules(Request $request): void
+    {
+        $class = self::class;
+
+        $validated = $request->validate($class::getValidationRules());
+    }
+
+    public function call_with_variable_method_nested_rules(Request $request): void
+    {
+        $method = 'craftRules';
+
+        $validated = $request->validate($this->{$method}());
+    }
+
+    public function call_with_foreign_class_validation_rules(Request $request): void
+    {
+        // Local helper shares the method name, but the callee is a different class.
+        $validated = $request->validate(\stdClass::getValidationRules());
+    }
+
     private function validateFormData(Request $request)
     {
         return $request->validate([

--- a/tests/App/Modules/Routes/Extractors/Ast/Stubs/controller.stub.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/Stubs/controller.stub.php
@@ -106,6 +106,45 @@ class TestController
         return response()->json('Hi');
     }
 
+    public function call_with_static_side_effect_assignment(Request $request): void
+    {
+        // Must not execute during extraction — previously wrote to the DB / ran app code.
+        $user = \Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast\Stubs\SideEffectStub::boom();
+
+        $validated = $request->validate([
+            'foobar' => 'required|string',
+        ]);
+    }
+
+    public function call_with_new_side_effect_assignment(Request $request): void
+    {
+        $instance = new \Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast\Stubs\SideEffectStub;
+
+        $validated = $request->validate([
+            'foobar' => 'required|string',
+        ]);
+    }
+
+    public function call_with_static_keyword_assignment(Request $request): void
+    {
+        // Relative keywords must not fatal ("Class 'static' not found") during extraction.
+        $query = static::missingMethodThatWouldFatal();
+
+        $validated = $request->validate([
+            'foobar' => 'required|string',
+        ]);
+    }
+
+    public function call_with_self_validation_rules(Request $request): void
+    {
+        $validated = $request->validate(self::getValidationRules());
+    }
+
+    public function call_with_static_validation_rules(Request $request): void
+    {
+        $validated = $request->validate(static::getValidationRules());
+    }
+
     private function validateFormData(Request $request)
     {
         return $request->validate([
@@ -129,6 +168,14 @@ class TestController
             'fooobazz' => "{$interpolation}|email{$interpolation2}",
             'baz' => "{$interpolation}|present".'|'.'email',
             'foobaz' => $rule,
+        ];
+    }
+
+    private static function getValidationRules(): array
+    {
+        return [
+            'name' => 'required|string',
+            'email' => 'required|email',
         ];
     }
 }

--- a/tests/App/Modules/Routes/Extractors/Ast/ValidateCallVisitorUnitTest.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/ValidateCallVisitorUnitTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Sunchayn\Nimbus\Modules\Routes\Extractor\Ast\ConvertNodeToConcreteValue;
 use Sunchayn\Nimbus\Modules\Routes\Extractor\Ast\ValidateCallVisitor;
 use Sunchayn\Nimbus\Modules\Schemas\Collections\Ruleset;
+use Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast\Stubs\SideEffectStub;
 use Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Stubs\StatusEnumStub;
 
 #[CoversClass(ValidateCallVisitor::class)]
@@ -139,6 +140,90 @@ class ValidateCallVisitorUnitTest extends TestCase
             'methodName' => 'nested_methods_calls',
             'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
             'expectedRules' => [], // <- Currently this is not supported.
+        ];
+
+        yield 'static call assignment with side effects' => [
+            'methodName' => 'call_with_static_side_effect_assignment',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'foobar' => 'required|string',
+            ],
+        ];
+
+        yield 'new instance assignment with side effects' => [
+            'methodName' => 'call_with_new_side_effect_assignment',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'foobar' => 'required|string',
+            ],
+        ];
+
+        yield 'static keyword assignment' => [
+            'methodName' => 'call_with_static_keyword_assignment',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'foobar' => 'required|string',
+            ],
+        ];
+
+        yield 'rules from self:: static call' => [
+            'methodName' => 'call_with_self_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'name' => 'required|string',
+                'email' => 'required|email',
+            ],
+        ];
+
+        yield 'rules from static:: static call' => [
+            'methodName' => 'call_with_static_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'name' => 'required|string',
+                'email' => 'required|email',
+            ],
+        ];
+    }
+
+    #[DataProvider('sideEffectScenariosDataProvider')]
+    public function test_it_does_not_execute_application_code_while_building_variable_context(
+        string $methodName,
+    ): void {
+        // Arrange
+
+        SideEffectStub::reset();
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse(file_get_contents(__DIR__.'/Stubs/controller.stub.php'));
+
+        $visitor = new ValidateCallVisitor($methodName);
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+
+        // Act
+
+        $traverser->traverse($ast);
+
+        // Assert
+
+        $this->assertFalse(
+            SideEffectStub::$called,
+            'Route extraction must not execute assigned StaticCall/New_ expressions.',
+        );
+        $this->assertEquals(
+            Ruleset::fromLaravelRules(['foobar' => 'required|string']),
+            $visitor->getRules(),
+        );
+    }
+
+    public static function sideEffectScenariosDataProvider(): Generator
+    {
+        yield 'static call assignment' => [
+            'methodName' => 'call_with_static_side_effect_assignment',
+        ];
+
+        yield 'new instance assignment' => [
+            'methodName' => 'call_with_new_side_effect_assignment',
         ];
     }
 }

--- a/tests/App/Modules/Routes/Extractors/Ast/ValidateCallVisitorUnitTest.php
+++ b/tests/App/Modules/Routes/Extractors/Ast/ValidateCallVisitorUnitTest.php
@@ -5,11 +5,13 @@ namespace Sunchayn\Nimbus\Tests\App\Modules\Routes\Extractors\Ast;
 use Generator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
+use PhpParser\Node\Name;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Sunchayn\Nimbus\Modules\Routes\Extractor\Ast\ConvertNodeToConcreteValue;
 use Sunchayn\Nimbus\Modules\Routes\Extractor\Ast\ValidateCallVisitor;
 use Sunchayn\Nimbus\Modules\Schemas\Collections\Ruleset;
@@ -183,6 +185,90 @@ class ValidateCallVisitorUnitTest extends TestCase
                 'email' => 'required|email',
             ],
         ];
+
+        yield 'rules from explicit class static call' => [
+            'methodName' => 'call_with_explicit_class_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [
+                'name' => 'required|string',
+                'email' => 'required|email',
+            ],
+        ];
+
+        yield 'unknown self:: helper yields no rules' => [
+            'methodName' => 'call_with_unknown_self_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [],
+        ];
+
+        yield 'variable class static call yields no rules' => [
+            'methodName' => 'call_with_variable_class_static_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [],
+        ];
+
+        yield 'variable method nested call yields no rules' => [
+            'methodName' => 'call_with_variable_method_nested_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [],
+        ];
+
+        yield 'foreign class static call with matching method name yields no rules' => [
+            'methodName' => 'call_with_foreign_class_validation_rules',
+            'phpCode' => file_get_contents(__DIR__.'/Stubs/controller.stub.php'),
+            'expectedRules' => [],
+        ];
+    }
+
+    public function test_it_uses_short_class_name_when_namespaced_name_is_unavailable(): void
+    {
+        // Arrange — bypass NameResolver so Class_::namespacedName is unset.
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse(<<<'PHP'
+            <?php
+
+            class CoverageController
+            {
+                public function action(): void
+                {
+                }
+            }
+            PHP);
+
+        $visitor = new ValidateCallVisitor('action');
+        $reflection = new ReflectionClass($visitor);
+        $gatherClassMethods = $reflection->getMethod('gatherClassMethods');
+        $gatherClassMethods->setAccessible(true);
+
+        // Act
+
+        $gatherClassMethods->invoke($visitor, $ast);
+
+        // Assert
+
+        $currentClassName = $reflection->getProperty('currentClassName');
+        $currentClassName->setAccessible(true);
+
+        $this->assertSame('CoverageController', $currentClassName->getValue($visitor));
+    }
+
+    public function test_it_rejects_static_calls_when_enclosing_class_name_is_unknown(): void
+    {
+        // Arrange
+
+        $visitor = new ValidateCallVisitor('action');
+        $reflection = new ReflectionClass($visitor);
+        $isCurrentClassReference = $reflection->getMethod('isCurrentClassReference');
+        $isCurrentClassReference->setAccessible(true);
+
+        // Act — currentClassName stays null when the enclosing class cannot be named.
+
+        $result = $isCurrentClassReference->invoke($visitor, new Name('SomeOtherClass'));
+
+        // Assert
+
+        $this->assertFalse($result);
     }
 
     #[DataProvider('sideEffectScenariosDataProvider')]


### PR DESCRIPTION
## Description

Stops Nimbus from executing application code (and fatalling on `static` / `self` / `parent`) while extracting route validation schemas.

## Motivation

Route extraction is meant to be **static analysis**. While building a variable context for rule substitution, Nimbus evaluated `StaticCall` and `New_` expressions found in controller methods. That caused failures when opening `/nimbus`:

1. **Fatal on relative class keywords** — controllers using `static::…` (common in packages like Filament API handlers) threw `Class "static" not found`.
2. **Side effects during extraction** — assignments like `User::create([...])` were actually executed, leading to DB writes / integrity constraint errors.
3. **Lost rules for `self::` / `static::` helpers** — `$request->validate(self::getValidationRules())` could not be extracted (and previously could fatal).

## How to reproduce

### Issue 1 — `Class "static" not found`

1. Register a route whose action contains a relative static call, e.g.:

```php
$query = static::getEloquentQuery();
```

2. Open the Nimbus UI at `/nimbus`.
3. Observe extraction failing with `Class "static" not found`.

### Issue 2 — DB side effects during extraction

1. Register a route whose action assigns from a static call / constructor with side effects, e.g.:

```php
$user = User::create([
    'name' => $validated['name'],
    // …
]);
```

2. Open `/nimbus` and observe extraction failing with a DB error because the call ran during extraction.

### Issue 3 — `self::getValidationRules()` not extracted

1. Register a route like:

```php
$validated = $request->validate(self::getValidationRules());
```

2. Open `/nimbus` and observe missing/failed schema extraction for that route.

## Changes

### `ValidateCallVisitor::storeVariableAssignment`

Skip `MethodCall`, `StaticCall`, and `New_` when building the variable context.

**Why:** Those expressions are only needed for optional rule substitution. Evaluating them runs real application code during schema extraction.

### `ValidateCallVisitor` nested `self` / `static` helpers

Treat `$request->validate(self::getValidationRules())` / `static::…` like `$this->craftRules()`: resolve the method on the class AST and read the returned rules array **without invoking** it.

Also guard `Ruleset::fromLaravelRules()` so non-array results fail soft instead of TypeError.

### `ConvertNodeToConcreteValue`

- Treat `static` / `self` / `parent` as unresolvable and return `null` instead of invoking them.
- Guard with `is_callable` / `class_exists` before invoking static calls or `new`.

**Why:** Defense-in-depth for paths that still resolve concrete values inside rule arrays (e.g. `Rule::in(...)`).

### Tests

- Extended `ValidateCallVisitorUnitTest` + controller stub scenarios for static/`new` assignments, `static::` keywords, and `self::` / `static::` validate helpers.
- Added `SideEffectStub` and assertions that extraction does **not** execute assigned calls.
- Added `ConvertNodeToConcreteValueUnitTest` covering relative keywords and a still-resolvable concrete static call (`Str::upper`).

## Testing

```bash
composer style:fix
composer test -- --filter='ConvertNodeToConcreteValueUnitTest|ValidateCallVisitorUnitTest'
```

**Manual:**

1. Open `/nimbus` in an app that previously failed on routes using `static::…`, `Model::create`, or `$request->validate(self::getValidationRules())`.
2. Confirm those routes extract without errors and no unexpected DB inserts occur.
